### PR TITLE
fix(launcher): correct argument splatting in Start-AitherZero.ps1

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -150,6 +150,10 @@ jobs:
         run: |
           Write-Host "Auto-creating version tag for main branch push..." -ForegroundColor Cyan
 
+          # Configure git identity for tagging
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
           $version = "${{ steps.version.outputs.version }}"
           $tagName = "v$version"
 
@@ -161,7 +165,7 @@ jobs:
             Write-Host "Creating and pushing tag: $tagName" -ForegroundColor Green
 
             # Create the tag
-            git tag $tagName -m "Automated release $tagName with batch launcher fixes and automated release workflow"
+            git tag $tagName -m "Automated release $tagName - CI/CD workflow fixes and enhanced build system"
 
             # Push the tag
             git push origin $tagName

--- a/templates/launchers/Start-AitherZero.ps1
+++ b/templates/launchers/Start-AitherZero.ps1
@@ -6,4 +6,4 @@ Write-Host '   Local Build - Essential Components Only' -ForegroundColor Yellow
 
 $env:PROJECT_ROOT = $PSScriptRoot
 
-& "$PSScriptRoot/aither-core.ps1" $args
+& "$PSScriptRoot/aither-core.ps1" @args


### PR DESCRIPTION
Fixes critical parameter passing issue in Windows launcher that was causing 'positional parameter cannot be found' error. Changes $args to @args for proper splatting.