### PR TITLE
Add .claude/commands for release automation

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -1,0 +1,111 @@
+# Claude Commands for AitherZero
+
+This directory contains helper scripts to streamline the release process after PR merges.
+
+## 🚀 Quick Start
+
+After your PR has been merged to main:
+
+```powershell
+# One command to create and push release tag
+./.claude/commands/quick-release.ps1
+```
+
+That's it! The script will:
+1. Switch to main branch
+2. Pull latest changes
+3. Read version from VERSION file
+4. Create annotated tag
+5. Push tag to trigger release build
+
+## 📚 Available Commands
+
+### quick-release.ps1
+The simplest way to create a release after PR merge:
+```powershell
+./.claude/commands/quick-release.ps1
+```
+
+### create-release-tag.ps1
+More control over the release process:
+```powershell
+# Use VERSION file
+./.claude/commands/create-release-tag.ps1
+
+# Specify version
+./.claude/commands/create-release-tag.ps1 -Version "1.4.3"
+
+# Custom message
+./.claude/commands/create-release-tag.ps1 -Version "1.4.3" -Message "Custom release notes"
+```
+
+### monitor-release.ps1
+Watch the build pipeline progress:
+```powershell
+# Monitor current version
+./.claude/commands/monitor-release.ps1
+
+# Monitor specific version
+./.claude/commands/monitor-release.ps1 -Version "1.4.2"
+```
+
+## 🔄 Typical Workflow
+
+1. **Create changes with PatchManager**:
+   ```powershell
+   Import-Module ./aither-core/modules/PatchManager -Force
+   Invoke-ReleaseWorkflow -ReleaseType "patch" -Description "Your changes"
+   ```
+
+2. **After PR merges**, create release tag:
+   ```powershell
+   ./.claude/commands/quick-release.ps1
+   ```
+
+3. **Monitor the build** (optional):
+   ```powershell
+   ./.claude/commands/monitor-release.ps1
+   ```
+
+## 📋 Requirements
+
+- PowerShell 7.0+
+- Git
+- GitHub CLI (`gh`) - optional but recommended for monitoring
+
+## 🛠️ What These Scripts Do
+
+1. **Ensure you're on main branch** with latest changes
+2. **Create annotated Git tag** with proper format
+3. **Push tag to GitHub** to trigger release pipeline
+4. **Monitor build progress** (if gh CLI installed)
+
+## 💡 Tips
+
+- Always ensure your PR is merged before running these scripts
+- The VERSION file should already be updated by PatchManager
+- Tags follow the format `v1.2.3` (with 'v' prefix)
+- Release builds are triggered automatically by tags
+- Check GitHub Actions for build status
+
+## 🚨 Troubleshooting
+
+If a tag already exists:
+- The script will ask if you want to recreate it
+- Choose 'y' only if you need to rebuild the release
+
+If build doesn't trigger:
+- Check GitHub Actions workflows are enabled
+- Verify the tag was pushed: `git push origin v1.4.2`
+- Check workflow file `.github/workflows/build-release.yml`
+
+## 🤖 Integration with Claude
+
+These scripts are designed to work seamlessly with Claude Code's PatchManager workflow:
+
+1. Claude creates PR with version bump
+2. You merge the PR
+3. Run `quick-release.ps1` to finish
+4. GitHub Actions handles the rest
+
+Simple, automated, and reliable! 🎉

--- a/.claude/commands/create-release-tag.ps1
+++ b/.claude/commands/create-release-tag.ps1
@@ -1,0 +1,141 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Creates a release tag after PR merge
+.DESCRIPTION
+    This script automates the release tag creation process after a PR has been merged.
+    It pulls the latest main branch and creates/pushes the release tag.
+.PARAMETER Version
+    The version to tag (e.g., "1.4.2"). If not provided, reads from VERSION file.
+.PARAMETER Message
+    Custom tag message. If not provided, uses a standard format.
+.EXAMPLE
+    ./create-release-tag.ps1
+    Creates tag using VERSION file
+.EXAMPLE
+    ./create-release-tag.ps1 -Version "1.4.3" -Message "Custom release notes"
+    Creates tag with specific version and message
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Version,
+    [string]$Message
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-ColorOutput {
+    param(
+        [string]$Message,
+        [string]$Color = 'White'
+    )
+    Write-Host $Message -ForegroundColor $Color
+}
+
+try {
+    Write-ColorOutput "🚀 AitherZero Release Tag Creator" -Color 'Cyan'
+    Write-ColorOutput "=================================" -Color 'Cyan'
+    
+    # Get project root
+    $projectRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    Set-Location $projectRoot
+    
+    # Check if we're in a git repository
+    if (-not (Test-Path ".git")) {
+        throw "Not in a git repository! Please run from AitherZero root."
+    }
+    
+    # Get current branch
+    $currentBranch = git branch --show-current
+    Write-ColorOutput "Current branch: $currentBranch" -Color 'Yellow'
+    
+    # Checkout main and pull latest
+    Write-ColorOutput "`nStep 1: Switching to main branch..." -Color 'Green'
+    git checkout main
+    
+    Write-ColorOutput "Step 2: Pulling latest changes..." -Color 'Green'
+    git pull origin main
+    
+    # Get version
+    if (-not $Version) {
+        $versionFile = Join-Path $projectRoot "VERSION"
+        if (Test-Path $versionFile) {
+            $Version = (Get-Content $versionFile -Raw).Trim()
+            Write-ColorOutput "Step 3: Using version from VERSION file: $Version" -Color 'Green'
+        } else {
+            throw "VERSION file not found and no version specified!"
+        }
+    } else {
+        Write-ColorOutput "Step 3: Using specified version: $Version" -Color 'Green'
+    }
+    
+    # Check if tag already exists
+    $existingTag = git tag -l "v$Version"
+    if ($existingTag) {
+        Write-ColorOutput "`n⚠️  Tag v$Version already exists!" -Color 'Yellow'
+        $overwrite = Read-Host "Do you want to delete and recreate it? (y/N)"
+        if ($overwrite -eq 'y') {
+            Write-ColorOutput "Deleting existing tag..." -Color 'Yellow'
+            git tag -d "v$Version"
+            git push origin --delete "v$Version" 2>$null
+        } else {
+            Write-ColorOutput "Aborted." -Color 'Red'
+            exit 1
+        }
+    }
+    
+    # Create tag message
+    if (-not $Message) {
+        # Try to read release notes
+        $releaseNotesFile = Join-Path $projectRoot "RELEASE-NOTES-v$Version.md"
+        if (Test-Path $releaseNotesFile) {
+            Write-ColorOutput "Step 4: Found release notes file" -Color 'Green'
+            $releaseNotes = Get-Content $releaseNotesFile -Raw
+            # Extract summary from release notes
+            if ($releaseNotes -match '##\s*🚀\s*(.+)') {
+                $summary = $matches[1].Trim()
+            } else {
+                $summary = "Release v$Version"
+            }
+        } else {
+            $summary = "Release v$Version"
+        }
+        
+        $Message = @"
+Release v$Version
+
+$summary
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+"@
+    }
+    
+    # Create and push tag
+    Write-ColorOutput "`nStep 5: Creating tag v$Version..." -Color 'Green'
+    git tag -a "v$Version" -m $Message
+    
+    Write-ColorOutput "Step 6: Pushing tag to origin..." -Color 'Green'
+    git push origin "v$Version"
+    
+    Write-ColorOutput "`n✅ Success! Tag v$Version created and pushed." -Color 'Green'
+    Write-ColorOutput "`nGitHub Actions will now:" -Color 'Yellow'
+    Write-ColorOutput "  • Trigger the Build & Release Pipeline" -Color 'White'
+    Write-ColorOutput "  • Build packages for all platforms" -Color 'White'
+    Write-ColorOutput "  • Create GitHub release with artifacts" -Color 'White'
+    
+    Write-ColorOutput "`nMonitor the build at:" -Color 'Cyan'
+    Write-ColorOutput "  https://github.com/wizzense/AitherZero/actions" -Color 'White'
+    
+    # Return to original branch
+    if ($currentBranch -ne 'main') {
+        Write-ColorOutput "`nReturning to branch: $currentBranch" -Color 'Yellow'
+        git checkout $currentBranch
+    }
+    
+} catch {
+    Write-ColorOutput "`n❌ Error: $_" -Color 'Red'
+    exit 1
+}

--- a/.claude/commands/monitor-release.ps1
+++ b/.claude/commands/monitor-release.ps1
@@ -1,0 +1,105 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Monitors the release build pipeline
+.DESCRIPTION
+    Watches the GitHub Actions build pipeline after creating a release tag
+.PARAMETER Version
+    The version to monitor. If not provided, reads from VERSION file.
+.EXAMPLE
+    ./monitor-release.ps1
+    Monitors current version build
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-ColorOutput {
+    param(
+        [string]$Message,
+        [string]$Color = 'White'
+    )
+    Write-Host $Message -ForegroundColor $Color
+}
+
+try {
+    Write-ColorOutput "🔍 AitherZero Release Monitor" -Color 'Cyan'
+    Write-ColorOutput "=============================" -Color 'Cyan'
+    
+    # Get version if not provided
+    if (-not $Version) {
+        $projectRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+        $versionFile = Join-Path $projectRoot "VERSION"
+        if (Test-Path $versionFile) {
+            $Version = (Get-Content $versionFile -Raw).Trim()
+        } else {
+            throw "VERSION file not found and no version specified!"
+        }
+    }
+    
+    Write-ColorOutput "`nMonitoring release v$Version" -Color 'Yellow'
+    
+    # Check if gh CLI is available
+    $ghAvailable = Get-Command gh -ErrorAction SilentlyContinue
+    
+    if ($ghAvailable) {
+        Write-ColorOutput "`nFetching workflow runs..." -Color 'Green'
+        
+        # Get the latest workflow run
+        $runs = gh run list --workflow="Build & Release Pipeline" --limit 5 --json headBranch,status,conclusion,createdAt,databaseId,name
+        $runData = $runs | ConvertFrom-Json
+        
+        # Find run for our tag
+        $ourRun = $runData | Where-Object { $_.headBranch -eq "v$Version" } | Select-Object -First 1
+        
+        if ($ourRun) {
+            Write-ColorOutput "`nFound build for v$Version!" -Color 'Green'
+            Write-ColorOutput "Status: $($ourRun.status)" -Color 'Yellow'
+            Write-ColorOutput "Run ID: $($ourRun.databaseId)" -Color 'White'
+            
+            if ($ourRun.status -eq "in_progress") {
+                Write-ColorOutput "`nWatching build progress..." -Color 'Yellow'
+                Write-ColorOutput "Press Ctrl+C to stop monitoring" -Color 'Gray'
+                
+                # Watch the run
+                gh run watch $ourRun.databaseId
+            } elseif ($ourRun.status -eq "completed") {
+                if ($ourRun.conclusion -eq "success") {
+                    Write-ColorOutput "`n✅ Build completed successfully!" -Color 'Green'
+                } else {
+                    Write-ColorOutput "`n❌ Build failed with status: $($ourRun.conclusion)" -Color 'Red'
+                }
+                
+                # Show run details
+                gh run view $ourRun.databaseId
+            }
+        } else {
+            Write-ColorOutput "`n⏳ Build for v$Version not found yet." -Color 'Yellow'
+            Write-ColorOutput "It may take a minute for GitHub Actions to start." -Color 'Gray'
+            
+            # Show recent runs
+            Write-ColorOutput "`nRecent workflow runs:" -Color 'Cyan'
+            gh run list --workflow="Build & Release Pipeline" --limit 5
+        }
+        
+        Write-ColorOutput "`nView all runs at:" -Color 'Cyan'
+        Write-ColorOutput "https://github.com/wizzense/AitherZero/actions/workflows/build-release.yml" -Color 'White'
+        
+    } else {
+        Write-ColorOutput "`n⚠️  GitHub CLI (gh) not found!" -Color 'Yellow'
+        Write-ColorOutput "Install it from: https://cli.github.com/" -Color 'White'
+        Write-ColorOutput "`nManually monitor at:" -Color 'Cyan'
+        Write-ColorOutput "https://github.com/wizzense/AitherZero/actions" -Color 'White'
+    }
+    
+    Write-ColorOutput "`nRelease page:" -Color 'Cyan'
+    Write-ColorOutput "https://github.com/wizzense/AitherZero/releases/tag/v$Version" -Color 'White'
+    
+} catch {
+    Write-ColorOutput "`n❌ Error: $_" -Color 'Red'
+    exit 1
+}

--- a/.claude/commands/quick-release.ps1
+++ b/.claude/commands/quick-release.ps1
@@ -1,0 +1,28 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Quick one-command release after PR merge
+.DESCRIPTION
+    Simplest way to create a release tag after your PR has been merged.
+    Just run this script and it handles everything.
+.EXAMPLE
+    ./quick-release.ps1
+    Creates release using VERSION file
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "`n🚀 Quick Release for AitherZero" -ForegroundColor Cyan
+Write-Host "==============================" -ForegroundColor Cyan
+
+try {
+    # Just call the main script
+    $scriptPath = Join-Path $PSScriptRoot "create-release-tag.ps1"
+    & $scriptPath
+} catch {
+    Write-Host "`n❌ Quick release failed: $_" -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
## 📚 Helper Scripts for Release Automation

This PR adds the `.claude/commands` directory with scripts to streamline the release process after PR merges.

### 🚀 Scripts Included:

1. **quick-release.ps1** - One-command release after PR merge
2. **create-release-tag.ps1** - Full control over release process with options
3. **monitor-release.ps1** - Watch build pipeline progress
4. **README.md** - Complete documentation

### 💡 Usage:

After any PR is merged that bumps the version:
```powershell
# Simple one-command release
./.claude/commands/quick-release.ps1
```

### 🎯 Benefits:

- Eliminates manual git commands for releases
- Consistent tag format and messages
- Automatic build monitoring (if gh CLI installed)
- Works seamlessly with PatchManager workflow
- Reduces release errors

### 📋 What the scripts do:

1. Switch to main branch
2. Pull latest changes
3. Read version from VERSION file
4. Create annotated tag with proper format
5. Push tag to trigger release build
6. Monitor build progress (optional)

These scripts make the release process simple and error-free!