### PR TITLE
fix: Update bootstrap.ps1 examples with correct GitHub repository URL

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -22,10 +22,10 @@
     Don't auto-start AitherZero after installation
 .EXAMPLE
     # One-liner installation (PowerShell 5.1+)
-    iwr -useb https://raw.githubusercontent.com/yourusername/AitherZero/main/bootstrap.ps1 | iex
+    iwr -useb https://raw.githubusercontent.com/wizzense/AitherZero/main/bootstrap.ps1 | iex
 
     # One-liner with options
-    & ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/yourusername/AitherZero/main/bootstrap.ps1))) -InstallProfile Developer -AutoInstallDeps
+    & ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/wizzense/AitherZero/main/bootstrap.ps1))) -InstallProfile Developer -AutoInstallDeps
 #>
 
 [CmdletBinding()]


### PR DESCRIPTION
## Summary
- Fixed GitHub URLs in bootstrap.ps1 examples from 'yourusername' to 'wizzense'
- Ensures users get the correct one-liner installation commands
- Aligns with actual repository location

## Changes
- Updated example URLs in bootstrap.ps1 documentation
- Changed from generic placeholder to actual repository owner

## Testing
- Verified bootstrap script functionality remains unchanged
- URLs now point to correct repository

## Impact
This is a documentation-only change that improves user experience by providing correct installation commands.